### PR TITLE
Feature/accept output format as config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Singer tap for replicating Pardot data.
   "api_output_type": "bulk"
 }
 ```
-The `client_id` and `client_secret` keys are your OAuth Salesforce App secrets. The refresh_token is a secret created during the OAuth flow. For more info on the Pardot OAuth flow, visit the Pardot [API documentation](https://developer.salesforce.com/docs/marketing/pardot/guide/authentication.html).
+The `client_id` and `client_secret` keys are your OAuth Salesforce App secrets. The `refresh_token` is a secret created during the OAuth flow. For more info on the Pardot OAuth flow, visit the Pardot [API documentation](https://developer.salesforce.com/docs/marketing/pardot/guide/authentication.html).
 
-The `start_data` is used by the tap as a bound on the query request, for more information about the format check [Singer best practices for dates](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#dates).
+The `start_date` is used by the tap as a bound on the query request, for more information about the format check [Singer best practices for dates](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#dates).
 
-The `api_output_type` is used to define the output on the API call. The default is "bulk" (more information on the "bulk" output call on [Query the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/bulk-data-pull.html#query-the-pardot-api)). With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields). If additional data is needed, change this variable (to either "simple" or "full"), and add the additional data explicitly to the select statement.
+The `api_output_type` is used to define the output on the API call. The default is "bulk" (more information on the "bulk" output call on [Query the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/bulk-data-pull.html#query-the-pardot-api) and [Changing the api response format](https://developer.salesforce.com/docs/marketing/pardot/guide/version-3-4-overview.html#changing-the-api-response-format)). With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields). If additional data is needed, change this variable (to either "simple" or "full"), and add the additional data explicitly to the select statement.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `client_id` and `client_secret` keys are your OAuth Salesforce App secrets. 
 
 The `start_data` is used by the tap as a bound on the query request, for more information about the format check [Singer best practices for dates](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#dates).
 
-The `api_output_type` is used to define the output on the API call. The default is "bulk" (more information on the "bulk" output call on [Query the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/bulk-data-pull.html#query-the-pardot-api)). With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields).
+The `api_output_type` is used to define the output on the API call. The default is "bulk" (more information on the "bulk" output call on [Query the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/bulk-data-pull.html#query-the-pardot-api)). With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields). If additional data is needed, change this variable (to either "simple" or "full"), and add the additional data explicitly to the select statement.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # tap-pardot
 Singer tap for replicating Pardot data.
 
+## Create a Config file
+```
+{
+  "client_id": "secret_client_id",
+  "client_secret": "secret_client_secret",
+  "refresh_token": "abc123",
+  "start_date": "2017-11-02T00:00:00Z",
+  "api_output_type": "bulk"
+}
+```
+The `client_id` and `client_secret` keys are your OAuth Salesforce App secrets. The refresh_token is a secret created during the OAuth flow. For more info on the Pardot OAuth flow, visit the Pardot [API documentation](https://developer.salesforce.com/docs/marketing/pardot/guide/authentication.html).
+
+The `start_data` is used by the tap as a bound on the query request, for more information about the format check [Singer best practices for dates](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#dates).
+
+The `api_output_type` is used to define the output on the API call. The default is "bulk" (more information on the "bulk" output call on [Query the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/bulk-data-pull.html#query-the-pardot-api)). With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields).
+
 ---
 
 Copyright &copy; 2019 Stitch

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -216,7 +216,7 @@ class Client:
     def describe(self, endpoint, **kwargs):
         url = (ENDPOINT_BASE + self.describe_url).format(endpoint, '{}')
 
-        params = {"format": "json", "output": "bulk", **kwargs}
+        params = {"format": "json", **kwargs}
 
         content = self._make_request("get", url, params)
 

--- a/tap_pardot/client.py
+++ b/tap_pardot/client.py
@@ -236,7 +236,7 @@ class Client:
             base_formatting.extend(format_params)
         url = (ENDPOINT_BASE + self.get_url).format(*base_formatting)
 
-        params = {"format": "json", "output": "bulk", **kwargs}
+        params = {"format": "json", **kwargs}
 
         content = self._make_request(method, url, params)
 

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -30,6 +30,9 @@ class Stream:
     def get_params(self):
         return {}
 
+    def get_api_output_type(self):
+        return self.config.get("api_output_type", "bulk")
+
     def get_bookmark(self):
         return (
             singer.bookmarks.get_bookmark(
@@ -116,6 +119,7 @@ class IdReplicationStream(Stream):
     def get_params(self):
         return {
             "created_after": self.config["start_date"],
+            "output": self.get_api_output_type(),
             "id_greater_than": self.get_bookmark(),
             "sort_by": "id",
             "sort_order": "ascending",
@@ -139,6 +143,7 @@ class UpdatedAtReplicationStream(Stream):
     def get_params(self):
         return {
             "updated_after": self.get_bookmark(),
+            "output": self.get_api_output_type(),
             "sort_by": "updated_at",
             "sort_order": "ascending",
         }
@@ -209,6 +214,7 @@ class NoUpdatedAtSortingStream(ComplexBookmarkStream):
     def get_params(self):
         return {
             "created_after": self.config["start_date"],
+            "output": self.get_api_output_type(),
             "id_greater_than": self.get_bookmark("id"),
             "sort_by": "id",
             "sort_order": "ascending",
@@ -265,6 +271,7 @@ class UpdatedAtSortByIdReplicationStream(ComplexBookmarkStream):
     def get_params(self):
         return {
             "id_greater_than": self.get_bookmark("id"),
+            "output": self.get_api_output_type(),
             "updated_after": self.get_bookmark("last_updated"),
             "sort_by": "id",
             "sort_order": "ascending",
@@ -459,6 +466,7 @@ class ListMemberships(ChildStream, NoUpdatedAtSortingStream):
             # filter by updated_after
             "updated_after": self.get_bookmark("updated_at")
             or self.config["start_date"],
+            "output": self.get_api_output_type(),
             "id_greater_than": self.get_bookmark("id") or 0,
             "sort_by": "id",
             "sort_order": "ascending",

--- a/tap_pardot/streams.py
+++ b/tap_pardot/streams.py
@@ -302,7 +302,10 @@ class ChildStream(ComplexBookmarkStream):
         super(ChildStream, self).post_sync()
 
     def get_params(self):
-        return {"offset": self.get_bookmark("offset")}
+        return {
+            "offset": self.get_bookmark("offset"),
+            "output": self.get_api_output_type(),
+        }
 
     def get_records(self, parent_ids):
         params = {self.parent_id_param: parent_ids, **self.get_params()}


### PR DESCRIPTION
# Description of change
- Added api_output_type as a configured parameter 
- Added a `get` method, to get this new parameter, having the default as "bulk"
- Adjusted all `get_param()` methods to use this new `get` method
- Added a small description on README about the config file 

WHY: 
With the bulk API call, the call is optimized, on the other hand, it doesn't return additional data in the response (such as nested objects and custom fields). When the EL job needs additional data, by simply adjusting the output as another (eg. simple), and adding the new fields to the select statement, these fields would be retrieved. 
 
# Risks
 - When not using "bulk", we lose the optimized API call 
 
# Rollback steps
 - revert this branch
